### PR TITLE
Add Makefile for Docker builds and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.RECIPEPREFIX := >
+
+VERSION ?= 11.8
+FLAVOR ?= base
+
+IMAGE_TAG := cudadocker:$(VERSION)-$(FLAVOR)
+IMAGE_DIR := images/$(VERSION)/$(FLAVOR)
+
+.PHONY: build test
+
+build: $(IMAGE_DIR)/Dockerfile
+>docker build -t $(IMAGE_TAG) $(IMAGE_DIR)
+
+test: build
+>docker run --rm -v $(PWD)/tests:/tests $(IMAGE_TAG) pytest /tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Dockerfiles are in images/<cuda-version>/<variant>.
 
+## Using the Makefile
+
+A Makefile wraps the image builds and basic tests.
+
+```bash
+# build the image at images/11.8/nvenc-torch
+make build VERSION=11.8 FLAVOR=nvenc-torch
+
+# run the test suite inside the built image
+make test VERSION=11.8 FLAVOR=nvenc-torch
+```
+
+The variables `VERSION` and `FLAVOR` map directly to the directory
+structure below `images/`. Adding new variants only requires creating the
+corresponding directory; the targets above will pick them up automatically.
+
 ## Cuda 11.8
 ### base
 docker build -t cudadocker:118_base images/11.8/base


### PR DESCRIPTION
## Summary
- add Makefile with parameterized `build` and `test` targets
- document new Makefile usage in README

## Testing
- `make -n build VERSION=11.8 FLAVOR=nvenc-torch`
- `make -n test VERSION=11.8 FLAVOR=nvenc-torch`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aadd962b748332a9309b0949cb7d61