### PR TITLE
Add workflow to build and test CUDA images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Docker Images CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "11.8"
+            flavor: "base"
+          - version: "11.8"
+            flavor: "nvenc"
+          - version: "11.8"
+            flavor: "nvenc-torch"
+          - version: "11.8"
+            flavor: "nvenc-torch2.0.1"
+          - version: "11.8"
+            flavor: "nvenc-torch-tensorflow"
+          - version: "12.5"
+            flavor: "base"
+          - version: "12.5"
+            flavor: "nvenc"
+          - version: "12.5"
+            flavor: "nvenc-torch"
+          - version: "12.5"
+            flavor: "nvenc-torch-tensorflow"
+          - version: "12.5"
+            flavor: "base-cudnn8"
+          - version: "12.5"
+            flavor: "nvenc-cudnn8"
+          - version: "12.5"
+            flavor: "nvenc-torch-cudnn8"
+          - version: "12.5"
+            flavor: "nvenc-torch-tensorflow-cudnn8"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: |
+          docker build -t cudadocker:${{ matrix.version }}-${{ matrix.flavor }} images/${{ matrix.version }}/${{ matrix.flavor }} 2>&1 | tee build.log
+      - name: Run tests
+        run: |
+          docker run --rm -v ${{ github.workspace }}/tests:/tests cudadocker:${{ matrix.version }}-${{ matrix.flavor }} pytest /tests 2>&1 | tee test.log
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs-${{ matrix.version }}-${{ matrix.flavor }}
+          path: |
+            build.log
+            test.log

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The variables `VERSION` and `FLAVOR` map directly to the directory
 structure below `images/`. Adding new variants only requires creating the
 corresponding directory; the targets above will pick them up automatically.
 
+## Continuous Integration
+
+A [GitHub Actions](.github/workflows/docker.yml) workflow builds each image and
+runs the test suite inside a container with `pytest`. Build and test logs are
+uploaded as artifacts to help with debugging.
+
 ## Cuda 11.8
 ### base
 docker build -t cudadocker:118_base images/11.8/base


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow building CUDA image matrix and running tests inside each container
- upload build and test logs as artifacts for debugging
- document the workflow in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aadee5e9c88332a086fb54cb8c2f6d